### PR TITLE
teleport: set the "gofuzz" build tag

### DIFF
--- a/projects/teleport/build.sh
+++ b/projects/teleport/build.sh
@@ -19,5 +19,5 @@ mkdir -p $GOPATH/src/github.com/gravitational
 cd $GOPATH/src/github.com/gravitational
 git clone https://github.com/gravitational/teleport.git
 
-compile_go_fuzzer github.com/gravitational/teleport/lib/fuzz FuzzParseProxyJump utils_fuzz
-compile_go_fuzzer github.com/gravitational/teleport/lib/fuzz FuzzNewExpression parse_fuzz
+compile_go_fuzzer github.com/gravitational/teleport/lib/fuzz FuzzParseProxyJump utils_fuzz gofuzz
+compile_go_fuzzer github.com/gravitational/teleport/lib/fuzz FuzzNewExpression parse_fuzz gofuzz


### PR DESCRIPTION
The file with teleport fuzzing functions is guarded with the `gofuzz` build tag: https://github.com/gravitational/teleport/blob/master/lib/fuzz/fuzz.go#L1
Pass this tag to `compile_go_fuzzer` to fix the build error:
```
Step #3: package github.com/gravitational/teleport/lib/fuzz: build constraints exclude all Go files in /root/go/src/github.com/gravitational/teleport/lib/fuzz
```

Note: I'm not sure what changed recently; this fuzzer used to work and broke on Jan 16th.